### PR TITLE
Fix unbound colorname variable error by initializing default color

### DIFF
--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -186,14 +186,13 @@ def annot_to_dict(
         result["author"] = "Unknown"
 
     # add color if present
+    colorname = "yellow"
     try:
         if annot["color"]:
             colorname = getColorName(annot["color"])
     except Exception as err:
-        print(f"Error when parsing color: '{err}'. Using yellow")
-        colorname = "yellow"
+        print(f"Error when parsing color: '{err}'. Using {colorname}")
     result["properties"]["color"] = colorname
-
 
     return result
 


### PR DESCRIPTION
Some annotations did not have a color defined in the annot dict.

This led to an UnboundLocalError because the variable colorname was being used without being initialized if the annotation's color data was absent and no exception was thrown.