### PR TITLE
exporting comment annotations

### DIFF
--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -291,7 +291,6 @@ def main(
 
             # extract text using PyMuPDF
             words = page.get_text("words")
-            content = None
             content = annot.info.get("content", "").strip()
             if content and handle_comments == 'replace':
                 text = content

--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -287,7 +287,11 @@ def main(
                     words,
                     keep_newlines,
                     text_boundary_threshold)
-            annotdict["contents"] = text
+            comment_text = annot.info["content"]
+            if comment_text:
+                annotdict["contents"] = comment_text
+            else:
+                annotdict["contents"] = text
             annotdict["color"] = annot.colors["fill"] if annot.colors["fill"] else annot.colors['stroke']
             annotdict["rect"] = annot.rect
             annotdict["quadpoints"] = []

--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -309,11 +309,8 @@ def main(
                     keep_newlines,
                     text_boundary_threshold)
             else:
-                try:
-                    raise ValueError(content)
-                except ValueError as err:
-                    print(err)
-                    continue
+                print(f"Error: unexpected handle_comments value. Content: {content}")
+                continue
             annotdict["contents"] = text
             annotdict["color"] = annot.colors["fill"] if annot.colors["fill"] else annot.colors['stroke']
             annotdict["rect"] = annot.rect

--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -11,6 +11,8 @@ import colour
 
 import fitz
 
+from typing import Literal
+
 
 COLORS = {
         'yellow': (1.0, 0.78431372549, 0.196078431373),
@@ -231,7 +233,7 @@ def main(
     keep_newlines: bool = True,
     text_boundary_threshold: float = 0.9,
     nonunique_uuid_do: str = "exit",
-    handle_comments: str = "auto",
+    handle_comments: Literal["auto", "replace", "ignore"] = "auto",
     ):
     """
     source: https://stackoverflow.com/questions/1106098/parse-annotations-from-a-pdf#12502560
@@ -259,7 +261,7 @@ def main(
         Leave to 'exit' to crash if there are non unique UUIDs.
         Note: The UUID for each block is a hash derived from its content so
         there really should be no reason to have duplicate UUIDs AFAIK.
-nonunique_uuid_do: str, default 'auto'
+    handle_comments: Literal, default 'auto'
         Set to 'auto' to add annotations from older apps to annotations from more recent apps.
         Set to 'replace' to automatically keep only annotations from older devices.
         Set to 'ignore' to not even check for other type of annotations.
@@ -291,7 +293,6 @@ nonunique_uuid_do: str, default 'auto'
             words = page.get_text("words")
             content = None
             content = annot.info.get("content", "").strip()
-            print(not content)
             if content and handle_comments == 'replace':
                 text = content
             elif handle_comments == 'auto':
@@ -301,7 +302,7 @@ nonunique_uuid_do: str, default 'auto'
                     keep_newlines,
                     text_boundary_threshold)
                 if content:
-                	text = text + '\n' + content 
+                	text = text.strip() + '\n' + content 
             elif handle_comments == 'ignore':
                 text = _extract_annot(
                     annot,

--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -294,19 +294,22 @@ nonunique_uuid_do: str, default 'auto'
             print(not content)
             if content and handle_comments == 'replace':
                 text = content
-            elif content and handle_comments == 'auto':
+            elif handle_comments == 'auto':
                 text = _extract_annot(
                     annot,
                     words,
                     keep_newlines,
                     text_boundary_threshold)
-                text = text + '\n' + content
+                if content:
+                	text = text + '\n' + content 
+            elif handle_comments == 'ignore':
+                text = _extract_annot(
+                    annot,
+                    words,
+                    keep_newlines,
+                    text_boundary_threshold)
             else:
-                text = _extract_annot(
-                    annot,
-                    words,
-                    keep_newlines,
-                    text_boundary_threshold)
+                raise ValueError(content)
             annotdict["contents"] = text
             annotdict["color"] = annot.colors["fill"] if annot.colors["fill"] else annot.colors['stroke']
             annotdict["rect"] = annot.rect

--- a/LogseqPDFImporter.py
+++ b/LogseqPDFImporter.py
@@ -301,8 +301,8 @@ def main(
                     words,
                     keep_newlines,
                     text_boundary_threshold)
-                if content:
-                	text = text.strip() + '\n' + content 
+                if not text:
+                	text = content
             elif handle_comments == 'ignore':
                 text = _extract_annot(
                     annot,
@@ -310,7 +310,11 @@ def main(
                     keep_newlines,
                     text_boundary_threshold)
             else:
-                raise ValueError(content)
+                try:
+                    raise ValueError(content)
+                except ValueError as err:
+                    print(err)
+                    continue
             annotdict["contents"] = text
             annotdict["color"] = annot.colors["fill"] if annot.colors["fill"] else annot.colors['stroke']
             annotdict["rect"] = annot.rect

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Import PDF into [logseq](https://github.com/logseq/logseq/) but also import anno
 ## Usage
 * `python -m pip install -r requirements.txt`
 * `python LogseqPDFImporter.py path_to_pdf --md_path path_to_md --edn_path path_to_edn`
+* `handle_comments` option (auto/replace/ignore) help with extracting annotations made with older apps (works for Adobe Acrobat Reader (v16.09.21) or PDF Reader under iOS 8 for example).
+`python LogseqPDFImporter.py path_to_pdf --md_path path_to_md --edn_path path_to_edn --handle_comments ignore`
+
 
 ## Example
 ### 1


### PR DESCRIPTION
Include comment annotations when exporting annotations.

Maybe we could make it so highlight annotations and comment annotations are differentiated.