### PR TITLE
pymupdf bug in 1.26.5 for get_area

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 simplejson>=3.19.2
 fire>=0.5.0
-pymupdf>=1.23.7
+pymupdf>=1.23.7,<1.26.5
 colour-science>=0.4.4


### PR DESCRIPTION
There is currently a bug with the latest release version of [PyMuPDF](https://github.com/pymupdf/PyMuPDF).
`AttributeError: 'Rect' object has no attribute 'get_area'`
I locked the requirements to stop at version 1.26.4

(I am also working on the other pull request).